### PR TITLE
Update README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -6,6 +6,8 @@ The ready to use image is available here:
 
 https://hub.docker.com/r/danixu86/project-zomboid-dedicated-server
 
+**WARNING:** Running the image on Windows using WSL2 in Docker Desktop will make the server startup times significantly slower. This is fine unless you are running alot of mods in which case server startup times may vary from 15 - 40 minutes. The best way to solve this problem is to run your container on a Linux based system or in a Linux VM.
+
 ## Environment variables
 
 This dockerfile converts some env variables to arguments in the server command, allowing to configure it. The image supports the following environment variables:


### PR DESCRIPTION
Added warning for slow startup times using WSL2 on Windows.
I have approximately >100 mods on the server and running the container on Docker Desktop on Windows using WSL2 made the server startup times unbearable, with the highest reaching 45 minutes.
After some research I found out that WSL2's file transfer performance is horrendous, so I moved the container to my ubuntu VM.
Starting the server on the VM now takes less than 2-3 minutes.