### PR TITLE
patch: ensure server data folder is accessible when using docker binding

### DIFF
--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -188,5 +188,9 @@ export LD_LIBRARY_PATH="${STEAMAPPDIR}/jre64/lib:${LD_LIBRARY_PATH}"
 
 ## Fix the permissions in the data and workshop folders
 chown -R 1000:1000 /home/steam/pz-dedicated/steamapps/workshop /home/steam/Zomboid
+# When binding a host folder with Docker to the container, the resulting folder has these permissions "d---" (i.e. NO `rwx`) 
+# which will cause runtime issues after launching the server.
+# Fix it the adding back `rwx` permissions for the file owner (steam user)
+chmod 755 /home/steam/Zomboid
 
 su - steam -c "export LANG=${LANG} && export LD_LIBRARY_PATH=\"${STEAMAPPDIR}/jre64/lib:${LD_LIBRARY_PATH}\" && cd ${STEAMAPPDIR} && pwd && ./start-server.sh ${ARGS}"


### PR DESCRIPTION
When binding a host folder with Docker to the container, the resulting folder has these permissions "d---" (i.e. NO `rwx`) which will cause runtime issues after launching the server.
Fix it the adding back `rwx` permissions for the file owner (steam user)