### PR TITLE
add option to force an update of steamclient.so

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -24,6 +24,8 @@ This dockerfile converts some env variables to arguments in the server command, 
 
 `FORCEUPDATE:` Force a server update on every start. This process can be slow if the image is old.
 
+`FORCESTEAMCLIENTSOUPDATE:` Forcibly update the steamclient.so libraries in the pz-dedicated directory before starting the server. May help with Workshop item downloads. Do not set if everything works fine.
+
 `IP:` Set the interface IP where the server will listen. By default all the interfaces.
 
 `MEMORY:` Amount of memory to use in the server JVM (units can be used, for example 2048m). By default 8096m.

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -8,6 +8,12 @@ cd ${STEAMAPPDIR}
 #                                   #
 #####################################
 
+if [ "${FORCESTEAMCLIENTSOUPDATE}" == "1" ]; then
+  echo "FORCESTEAMCLIENTSOUPDATE variable is set, updating steamclient.so in Zomboid's server"
+  cp "${STEAMCMDDIR}/linux64/steamclient.so" "${STEAMAPPDIR}/linux64/steamclient.so"
+  cp "${STEAMCMDDIR}/linux32/steamclient.so" "${STEAMAPPDIR}/steamclient.so"
+fi
+
 if [ "${FORCEUPDATE}" == "1" ]; then
   echo "FORCEUPDATE variable is set, so the server will be updated right now"
   bash "${STEAMCMDDIR}/steamcmd.sh" +force_install_dir "${STEAMAPPDIR}" +login anonymous +app_update "${STEAMAPPID}" validate +quit


### PR DESCRIPTION
This adds an option to force an update of steamclient.so fixing the currently ongoing issue with updating workshop mods.