### PR TITLE
feat: add STEAMAPPBRANCH build arg for beta branch support

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,5 @@
 # Empty Strings are ignored or equivalent to false
+# STEAMAPPBRANCH=unstable
 LANG=en_EN.UTF-8
 NOSTEAM=False
 CACHEDIR=

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,15 @@ FROM cm2network/steamcmd:root
 LABEL maintainer="daniel.carrasco@electrosoftcloud.com"
 
 ENV STEAMAPPID=380870
-ENV STEAMAPPBRANCH=""
 ENV STEAMAPP=pz
 ENV STEAMAPPDIR="${HOMEDIR}/${STEAMAPP}-dedicated"
 # Fix for a new installation problem in the Steamcmd client
 ENV HOME="${HOMEDIR}"
+
+# Receive the value from docker-compose as an ARG
+ARG STEAMAPPBRANCH=""
+# Promote the ARG value to an ENV for runtime
+ENV STEAMAPPBRANCH=$STEAMAPPBRANCH
 
 # Install required packages
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM cm2network/steamcmd:root
 LABEL maintainer="daniel.carrasco@electrosoftcloud.com"
 
 ENV STEAMAPPID=380870
+ARG STEAMAPPBRANCH=""
 ENV STEAMAPP=pz
 ENV STEAMAPPDIR="${HOMEDIR}/${STEAMAPP}-dedicated"
 # Fix for a new installation problem in the Steamcmd client
@@ -30,7 +31,7 @@ RUN set -x \
   && chown -R "${USER}:${USER}" "${STEAMAPPDIR}" \
   && bash "${STEAMCMDDIR}/steamcmd.sh" +force_install_dir "${STEAMAPPDIR}" \
   +login anonymous \
-  +app_update "${STEAMAPPID}" validate \
+  +app_update "${STEAMAPPID}" ${STEAMAPPBRANCH:+-beta "$STEAMAPPBRANCH"} validate \
   +quit
 
 # Copy the entry point file

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM cm2network/steamcmd:root
 LABEL maintainer="daniel.carrasco@electrosoftcloud.com"
 
 ENV STEAMAPPID=380870
-ARG STEAMAPPBRANCH=""
+ENV STEAMAPPBRANCH=""
 ENV STEAMAPP=pz
 ENV STEAMAPPDIR="${HOMEDIR}/${STEAMAPP}-dedicated"
 # Fix for a new installation problem in the Steamcmd client

--- a/README.MD
+++ b/README.MD
@@ -6,6 +6,8 @@ The ready to use image is available here:
 
 https://hub.docker.com/r/danixu86/project-zomboid-dedicated-server
 
+> **Note:** If you want to play **Build 42** multiplayer, you must set the `STEAMAPPBRANCH` [build argument](#build-arguments) to `unstable`.
+
 **WARNING:** Running the image on Windows using WSL2 in Docker Desktop will make the server startup times significantly slower. This is fine unless you are running alot of mods in which case server startup times may vary from 15 - 40 minutes. The best way to solve this problem is to run your container on a Linux based system or in a Linux VM.
 
 ## Environment variables
@@ -57,6 +59,30 @@ This dockerfile converts some env variables to arguments in the server command, 
 Mods will install on second server start
 
 Maps are added on third server start, after mods are added
+
+## Build arguments
+
+The Dockerfile supports the following build arguments:
+
+`STEAMAPPBRANCH`: Sets the Steam beta branch to download (e.g., `unstable`). If not set, the stable branch is used.
+
+### Example using docker build
+
+```bash
+docker build --build-arg STEAMAPPBRANCH=unstable -t project-zomboid-server .
+```
+
+### Example using docker-compose
+
+```yaml
+services:
+  zomboid-server:
+    build:
+      context: .
+      args:
+        STEAMAPPBRANCH: unstable
+```
+
 ## Soft Reset
 
 Soft reset will perform the following tasks:

--- a/README.MD
+++ b/README.MD
@@ -6,7 +6,7 @@ The ready to use image is available here:
 
 https://hub.docker.com/r/danixu86/project-zomboid-dedicated-server
 
-> **Note:** If you want to play **Build 42** multiplayer, you must set the `STEAMAPPBRANCH` [build argument](#build-arguments) to `unstable`.
+> **Note:** If you want to play **Build 42** multiplayer, you must set the `STEAMAPPBRANCH` [environment variable](#environment-variables) to `unstable`.
 
 **WARNING:** Running the image on Windows using WSL2 in Docker Desktop will make the server startup times significantly slower. This is fine unless you are running alot of mods in which case server startup times may vary from 15 - 40 minutes. The best way to solve this problem is to run your container on a Linux based system or in a Linux VM.
 
@@ -56,32 +56,13 @@ This dockerfile converts some env variables to arguments in the server command, 
 
 `LANG:` This env variable will set the container locales, which will be used by the pz server to set the language. Example (en_EN.UTF-8, es_ES.UTF-8...)
 
+`STEAMAPPBRANCH:` Sets the Steam beta branch to download (e.g., `unstable`). If not set, the stable branch is used.
+
 Mods will install on second server start
 
 Maps are added on third server start, after mods are added
 
-## Build arguments
 
-The Dockerfile supports the following build arguments:
-
-`STEAMAPPBRANCH`: Sets the Steam beta branch to download (e.g., `unstable`). If not set, the stable branch is used.
-
-### Example using docker build
-
-```bash
-docker build --build-arg STEAMAPPBRANCH=unstable -t project-zomboid-server .
-```
-
-### Example using docker-compose
-
-```yaml
-services:
-  zomboid-server:
-    build:
-      context: .
-      args:
-        STEAMAPPBRANCH: unstable
-```
 
 ## Soft Reset
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        # Reads STEAMAPPBRANCH from your .env file to set the build version (ARG).
+        - STEAMAPPBRANCH=${STEAMAPPBRANCH}
     env_file:
       - .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        # STEAMAPPBRANCH: unstable
     env_file:
       - .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        # STEAMAPPBRANCH: unstable
     env_file:
       - .env
     ports:

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -16,7 +16,7 @@ fi
 
 if [ "${FORCEUPDATE}" == "1" ]; then
   echo "FORCEUPDATE variable is set, so the server will be updated right now"
-  bash "${STEAMCMDDIR}/steamcmd.sh" +force_install_dir "${STEAMAPPDIR}" +login anonymous +app_update "${STEAMAPPID}" validate +quit
+  bash "${STEAMCMDDIR}/steamcmd.sh" +force_install_dir "${STEAMAPPDIR}" +login anonymous +app_update "${STEAMAPPID}" ${STEAMAPPBRANCH:+-beta "$STEAMAPPBRANCH"} validate +quit
 fi
 
 


### PR DESCRIPTION
- Added `STEAMAPPBRANCH` ARG to Dockerfile to allow installing beta branches (e.g. `unstable`).
- Updated `steamcmd` command to conditionally use `-beta` flag.
- Added example usage to `docker-compose.yml`.
- Updated `README.md` with documentation, usage examples, and a note about Build 42 multiplayer.