### PR TITLE
RCON Password fix and Public server related settings

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -20,6 +20,12 @@ This image uses some env variables as arguments in the server command, allowing 
 
 `PASSWORD:` Sets or changes server password. Is optional.
 
+`RCONPASSWORD:` Sets or changes RCON  password. Must be secure.
+
+`PUBLIC:` Shows the server on the in-game browser if `true`, Hides it if `false`. Keeps the setting in the setting file if unset (`false` at first start). 
+
+`DISPLAYNAME:` Sets or changes the servers name in the server browser. Keeps the setting in the setting file if unset.  
+
 `CACHEDIR:` Set the folder where the data will be stored. By default the server stores the data in the Zomboid folder in home directory (/home/steam/Zomboid). Is recommended to store this data into a persistent volume to keep the server state.
 
 `DEBUG:` Enable the debug mode in server

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -145,7 +145,23 @@ if [ -n "${STEAMPORT2}" ]; then
 fi
 
 if [ -n "${PASSWORD}" ]; then
-	sed -i "s/Password=.*/Password=${PASSWORD}/" "${HOMEDIR}/Zomboid/Server/${SERVERNAME}.ini"
+	sed -i "s/^Password=.*/Password=${PASSWORD}/" "${HOMEDIR}/Zomboid/Server/${SERVERNAME}.ini"
+fi
+
+if [ -n "${RCONPASSWORD}" ]; then
+	sed -i "s/^RCONPassword=.*/RCONPassword=${RCONPASSWORD}/" "${HOMEDIR}/Zomboid/Server/${SERVERNAME}.ini"
+fi
+
+# Shows the server on the in-game browser.
+if [ "${PUBLIC}" == "1" ] || [ "${PUBLIC,,}" == "true"]; then
+  sed -i "s/^Public=.*/Public=true/" "${HOMEDIR}/Zomboid/Server/${SERVERNAME}.ini"
+else if [ "${PUBLIC}" == "0" ] || [ "${PUBLIC,,}" == "false"]; then
+  sed -i "s/^Public=.*/Public=false/" "${HOMEDIR}/Zomboid/Server/${SERVERNAME}.ini"
+fi
+
+# Set the display name for the server.
+if [ -n "${DISPLAYNAME}" ]; then
+  sed -i "s/^PublicName=.*/PublicName=${DISPLAYNAME}/" "${HOMEDIR}/Zomboid/Server/${SERVERNAME}.ini"
 fi
 
 if [ -n "${MOD_IDS}" ]; then


### PR DESCRIPTION
### Fix
The PASSWORD env variable previously set the RCONPassword as well as the server password, the regex has been modified to take the line break into account.
A separate RCONPASSWORD variable has been added.

### Feature
Added the PUBLIC and DISPLAYNAME settings that allow controlling the basic display settings of the server in the in-game server browser. I made it so that it doesn't break if someone keeps their old .env file and had the values manually configured in the .ini file.