### PR TITLE
feat: add min/max JVM memory support

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -36,7 +36,11 @@ This image uses some env variables as arguments in the server command, allowing 
 
 `IP:` Set the interface IP where the server will listen. By default all the interfaces.
 
-`MEMORY:` Amount of memory to use in the server JVM (units can be used, for example 2048m). By default 8096m.
+`MIN_MEMORY:` Initial memory allocation for the JVM (e.g., 2048m).
+
+`MAX_MEMORY:` Maximum memory limit for the JVM (e.g., 4096m).
+
+`MEMORY:` Amount of memory to use in the server JVM (e.g., 8096m). This variable is used as a fallback for both minimum and maximum memory if `MIN_MEMORY` and `MAX_MEMORY` are not defined.
 
 `MODFOLDERS`: Mod folders to use to load the game mods. Allowed options are workshop, steam, and mods. Options must be separated by comma, for example: workshop,steam,mods
 

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -28,8 +28,10 @@ fi
 ARGS=""
 
 # Set the server memory. Units are accepted (1024m=1Gig, 2048m=2Gig, 4096m=4Gig): Example: 1024m
-if [ -n "${MEMORY}" ]; then
-  ARGS="${ARGS} -Xmx${MEMORY} -Xms${MEMORY}"
+if [ -n "${MIN_MEMORY}" ] && [ -n "${MAX_MEMORY}" ]; then
+  ARGS="${ARGS} -Xms${MIN_MEMORY} -Xmx${MAX_MEMORY}"
+elif [ -n "${MEMORY}" ]; then
+  ARGS="${ARGS} -Xms${MEMORY} -Xmx${MEMORY}"
 fi
 
 # Option to perform a Soft Reset


### PR DESCRIPTION
Change rationale:
In my specific case, the server runs with this configuration on a machine that hosts multiple game servers. Since memory allocation is not critical and at peak we only reach about six players (not all connected simultaneously), I wanted to avoid the server constantly consuming 8GB of RAM.
This modification is not essential for my setup, but I added it to improve flexibility. The update preserves backward compatibility: if  or  are not defined, the server will continue to behave as before by relying on the existing  variable. While I don’t strictly need this change, I believe it could be useful for others using the same Docker setup.
Thanks for reviewing!

Changes:
- Updated entry.sh to prioritize MIN_MEMORY and MAX_MEMORY variables.
- Updated README to document new variables and the MEMORY fallback logic.