### PR TITLE
fix: misconfigured/duplicated environment variable

### DIFF
--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -141,7 +141,7 @@ if [ -n "${STEAMPORT1}" ]; then
   ARGS="${ARGS} -steamport1 ${STEAMPORT1}"
 fi
 if [ -n "${STEAMPORT2}" ]; then
-  ARGS="${ARGS} -steamport2 ${STEAMPORT1}"
+  ARGS="${ARGS} -steamport2 ${STEAMPORT2}"
 fi
 
 if [ -n "${PASSWORD}" ]; then


### PR DESCRIPTION
I was poking around in entry.sh and noticed a tiny hiccup with the steam ports. Even though those ports aren’t really used anymore, I figured I’d fix it anyway — it’s one of those “why not?” kind of changes. Nothing major, just cleaning things up so the script looks a bit tidier and doesn’t trip anyone up down the line.