### PR TITLE
Allow Steam public branch when STEAMAPPBRANCH is unset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,17 @@ RUN sed -i 's/^# *\(es_ES.UTF-8\)/\1/' /etc/locale.gen \
 RUN set -x \
   && mkdir -p "${STEAMAPPDIR}" \
   && chown -R "${USER}:${USER}" "${STEAMAPPDIR}" \
-  && bash "${STEAMCMDDIR}/steamcmd.sh" +force_install_dir "${STEAMAPPDIR}" \
-  +login anonymous \
-  +app_update "${STEAMAPPID}" -beta "${STEAMAPPBRANCH}" validate \
-  +quit
+  && if [ "${STEAMAPPBRANCH}" = "public" ]; then \
+       bash "${STEAMCMDDIR}/steamcmd.sh" +force_install_dir "${STEAMAPPDIR}" \
+       +login anonymous \
+       +app_update "${STEAMAPPID}" validate \
+       +quit; \
+     else \
+       bash "${STEAMCMDDIR}/steamcmd.sh" +force_install_dir "${STEAMAPPDIR}" \
+       +login anonymous \
+       +app_update "${STEAMAPPID}" -beta "${STEAMAPPBRANCH}" validate \
+       +quit; \
+     fi
 
 # Copy the entry point file
 COPY --chown=${USER}:${USER} scripts/entry.sh /server/scripts/entry.sh


### PR DESCRIPTION
Project Zomboid Build 42 is now available on the public branch. The Dockerfile currently always passes -beta ${STEAMAPPBRANCH} to SteamCMD, which prevents using the default public branch. This change makes the beta branch optional while preserving existing unstable branch behavior.

Not sure what implementation you'd prefer, but the main issue with current main is presented here with a possible fix. On my instance I just hacked out the -beta and steam branch part of the Dockerfile just to get moving, but this is optional logic to support -beta as well. Thanks!