### PR TITLE
fix(readme): link to envs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -6,7 +6,7 @@ The ready to use image is available here:
 
 https://hub.docker.com/r/danixu86/project-zomboid-dedicated-server
 
-> **Note:** If you want to play **Build 42** multiplayer, you must set the `STEAMAPPBRANCH` [environment variable](#environment-variables) to `unstable`.
+> **Note:** If you want to play **Build 42** multiplayer, you must set the `STEAMAPPBRANCH` [environment variable](#run-time-environment-variables) to `unstable`.
 
 **WARNING:** Running the image on Windows using WSL2 in Docker Desktop will make the server startup times significantly slower. This is fine unless you are running alot of mods in which case server startup times may vary from 15 - 40 minutes. The best way to solve this problem is to run your container on a Linux based system or in a Linux VM.
 


### PR DESCRIPTION
Heading was changed to "Run time environment variables" from "Environment variables", so the link got stale.