### PR TITLE
Added support for special characters

### DIFF
--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -165,10 +165,14 @@ fi
 
 # Set an option in the server INI file: replace it when present, append it when missing.
 set_ini_option() {
-  if grep -q "^${1}=" "${SERVERINI}"; then
-    sed -i "s|^${1}=.*|${1}=${2}|" "${SERVERINI}"
+  local key="$1"
+  local value="$2"
+
+  if grep -q "^${key}=" "${SERVERINI}"; then
+    value=$(printf '%s' "$value" | sed 's/[&|\\]/\\&/g')
+    sed -i "s|^${key}=.*|${key}=${value}|" "${SERVERINI}"
   else
-    echo "${1}=${2}" >> "${SERVERINI}"
+    printf '%s=%s\n' "$key" "$value" >> "${SERVERINI}"
   fi
 }
 


### PR DESCRIPTION
## Summary

Fix `set_ini_option()` to safely handle special characters in configuration values.

## Changes

* Escape `&`, `|`, and `\` before passing values to `sed`.
* Use local variables for improved readability.
* Use `printf` instead of `echo` when appending new options.
* Prevent values such as `[J&G] Desert Multicam Uniform` from being corrupted when updating the INI file.

## Example

Previously, a value containing `&` could be incorrectly interpreted by `sed`:

```ini
MOD_IDS=[J&G] Desert Multicam Uniform
```

The updated implementation correctly preserves the value as provided.

## Testing

Verified that INI values containing special characters are correctly updated and written without modification.
