### PR TITLE
fix: several first boot and configuration bugs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,6 @@
 # Empty Strings are ignored or equivalent to false
 # STEAMAPPBRANCH=unstable
-LANG=en_EN.UTF-8
+LANG=en_US.UTF-8
 NOSTEAM=False
 CACHEDIR=
 MODFOLDERS=workshop,steam,mods

--- a/.env.template
+++ b/.env.template
@@ -21,3 +21,30 @@ MOD_IDS=
 WORKSHOP_IDS=
 PROJECT_ZOMBOID_DATA=./data
 PROJECT_ZOMBOID_WORKSHOP_MODS=./workshop-mods
+
+# --- Optional variables, all of them documented in the README ---
+# Uncomment the ones you need. They are commented out because an unset variable keeps
+# whatever is already written in the server INI file.
+# Server and RCON passwords
+#PASSWORD=
+#RCONPASSWORD=
+# Shows (true) or hides (false) the server in the in-game browser
+#PUBLIC=
+# Name shown in the server browser
+#DISPLAYNAME=
+# JVM memory. When both are set, they take precedence over MEMORY
+#MIN_MEMORY=2048m
+#MAX_MEMORY=4096m
+# Runs a coop server instead of a dedicated one
+#COOP=False
+# Keeps the Mods and WorkshopItems entries of the INI file untouched
+#SELF_MANAGED_MODS=False
+# Updates the server on every start
+#FORCEUPDATE=False
+# Refreshes the steamclient.so libraries before starting. Only needed when the Workshop
+# downloads are failing
+#FORCESTEAMCLIENTSOUPDATE=False
+# Overwrites an already existing SandboxVars file with the one from SERVERPRESET
+#SERVERPRESETREPLACE=False
+# Build time only: extra locales to generate in the image, so LANG can select them
+#EXTRA_LOCALES=es_ES.UTF-8

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# The shell scripts are copied into a Linux image and executed there, so they must keep
+# LF endings no matter what core.autocrlf is set to on the machine that clones the repo.
+# A CRLF checkout is what the `dos2unix` call in the Dockerfile and the `sed -i 's/\r$//'`
+# in the entrypoint are working around at runtime.
+*.sh text eol=lf
+Dockerfile text eol=lf
+*.yml text eol=lf
+.env.template text eol=lf

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout the latest version
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,14 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-# Generate locales to allow other languages in the PZ Server
-RUN sed -i 's/^# *\(es_ES.UTF-8\)/\1/' /etc/locale.gen \
+# Generate locales to allow other languages in the PZ Server.
+# The base image already generates en_US.UTF-8. Any other locale you want to be able to
+# select through the LANG variable has to be generated here, so list them (space
+# separated) in this argument.
+ARG EXTRA_LOCALES="es_ES.UTF-8"
+RUN for extra_locale in ${EXTRA_LOCALES}; do \
+      sed -i "s/^# *\(${extra_locale}\)/\1/" /etc/locale.gen; \
+    done \
   # Generate locale
   && locale-gen
 

--- a/README.MD
+++ b/README.MD
@@ -28,6 +28,8 @@ This image uses some env variables as arguments in the server command, allowing 
 
 `CACHEDIR:` Set the folder where the data will be stored. By default the server stores the data in the Zomboid folder in home directory (/home/steam/Zomboid). Is recommended to store this data into a persistent volume to keep the server state.
 
+`COOP:` Runs a coop server instead of a dedicated server. Disables the default admin from being accessible. Disabled by default.
+
 `DEBUG:` Enable the debug mode in server
 
 `FORCEUPDATE:` Force a server update on every start. This process can be slow if the image is old.
@@ -72,7 +74,7 @@ This image uses some env variables as arguments in the server command, allowing 
 
 Mods will install on second server start
 
-Maps are added on third server start, after mods are added
+Maps are added on the same start on which the mods are detected, right after the workshop items have been downloaded.
 
 ## Build time environment variables
 

--- a/README.MD
+++ b/README.MD
@@ -64,7 +64,7 @@ This image uses some env variables as arguments in the server command, allowing 
 
 `WORKSHOP_IDS:` Semicolon separated list of Workshop IDs to install to the server. Leaving this empty will clear any existing value!
 
-`MOD_IDS:` Semicolon separated list of Mod IDs to install to the server. NOTE - B42 changes the way mod IDs must be supplied (\mod1;\mod2 inside the servertest.ini file) when defining this variable, preceed each mod id with two backslashes (\\) to escape the backslash into the ini file.
+`MOD_IDS:` Semicolon separated list of Mod IDs to install to the server. NOTE - B42 changes the way mod IDs must be supplied (\mod1;\mod2 inside the servertest.ini file) when defining this variable, preceed each mod id with two backslashes (\\) to escape the backslash into the ini file. Leaving this empty will clear any existing value, the same way `WORKSHOP_IDS` does. Use `SELF_MANAGED_MODS` if you want to keep the value written in the INI file.
 
 `SELF_MANAGED_MODS:` When set to `1` or `true`, the container will NOT modify the `Mods` or `WorkshopItems` entries in the server INI. Use this if you manage mods/workshop items externally (for example via bind mounts or an external workshop manager). Default behavior (when unset or `false`) is for the entrypoint script to update `Mods` and `WorkshopItems` based on `MOD_IDS`/`WORKSHOP_IDS`.
 

--- a/README.MD
+++ b/README.MD
@@ -68,7 +68,7 @@ This image uses some env variables as arguments in the server command, allowing 
 
 `SELF_MANAGED_MODS:` When set to `1` or `true`, the container will NOT modify the `Mods` or `WorkshopItems` entries in the server INI. Use this if you manage mods/workshop items externally (for example via bind mounts or an external workshop manager). Default behavior (when unset or `false`) is for the entrypoint script to update `Mods` and `WorkshopItems` based on `MOD_IDS`/`WORKSHOP_IDS`.
 
-`LANG:` This env variable will set the container locales, which will be used by the pz server to set the language. Example (en_EN.UTF-8, es_ES.UTF-8...)
+`LANG:` This env variable will set the container locales, which will be used by the pz server to set the language. Example (en_US.UTF-8, es_ES.UTF-8...). Only the locales generated in the image can be used: the base image provides `en_US.UTF-8` and the image adds the ones listed in the `EXTRA_LOCALES` build argument. A warning is printed on startup when the requested locale is missing.
 
 Mods will install on second server start
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   ProjectZomboidDedicatedServer:
     image: danixu86/project-zomboid-dedicated-server:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       args:
         # Reads STEAMAPPBRANCH from your .env file to set the build version (ARG).
         - STEAMAPPBRANCH=${STEAMAPPBRANCH}
+        # Extra locales to generate in the image, so they can be selected with LANG.
+        - EXTRA_LOCALES=${EXTRA_LOCALES:-es_ES.UTF-8}
     env_file:
       - .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,11 @@ services:
     env_file:
       - .env
     ports:
-      - "16261:16261/udp"
-      - "16262:16262/udp"
+      # Follow the PORT and UDPPORT variables from the .env file. With the ports hardcoded,
+      # changing them left the server listening on a port that was never published, so it
+      # was unreachable from outside the container.
+      - "${PORT:-16261}:${PORT:-16261}/udp"
+      - "${UDPPORT:-16262}:${UDPPORT:-16262}/udp"
       - "27015:27015/tcp"
     volumes:
       # Server data

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -284,6 +284,13 @@ if [ -d "${WORKSHOP_CONTENT_DIR}" ]; then
   fi
 fi
 
+# The server picks its language from LANG, but a locale that was never generated in the
+# image is silently ignored by glibc, so the language change looks like it did nothing.
+# Warn about it instead, pointing at the build argument that generates extra locales.
+if [ -n "${LANG}" ] && ! locale -a 2>/dev/null | grep -qix "${LANG/.UTF-8/.utf8}"; then
+  echo "*** WARNING: the locale ${LANG} is not generated in this image, so the server will fall back to the default one. Rebuild the image with --build-arg EXTRA_LOCALES=\"${LANG}\" to add it ***"
+fi
+
 # Fix to a bug in start-server.sh that causes to no preload a library:
 # ERROR: ld.so: object 'libjsig.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
 export LD_LIBRARY_PATH="${STEAMAPPDIR}/jre64/lib:${LD_LIBRARY_PATH}"

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -16,7 +16,16 @@ fi
 
 if [ "${FORCEUPDATE}" == "1" ] || [ "${FORCEUPDATE,,}" == "true" ]; then
   echo "FORCEUPDATE variable is set, so the server will be updated right now"
-  bash "${STEAMCMDDIR}/steamcmd.sh" +force_install_dir "${STEAMAPPDIR}" +login anonymous +app_update "${STEAMAPPID}" -beta "${STEAMAPPBRANCH}" validate +quit
+  # The public branch is not a beta: passing `-beta public` makes SteamCMD look for a
+  # non existent beta, so the update silently does nothing and the server keeps running
+  # the version baked into the image. This is the same condition the Dockerfile uses at
+  # build time.
+  if [ -z "${STEAMAPPBRANCH}" ] || [ "${STEAMAPPBRANCH}" == "public" ]; then
+    STEAMAPPBRANCH_ARGS=()
+  else
+    STEAMAPPBRANCH_ARGS=(-beta "${STEAMAPPBRANCH}")
+  fi
+  bash "${STEAMCMDDIR}/steamcmd.sh" +force_install_dir "${STEAMAPPDIR}" +login anonymous +app_update "${STEAMAPPID}" "${STEAMAPPBRANCH_ARGS[@]}" validate +quit
 fi
 
 

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -217,6 +217,9 @@ else
   if [ -n "${MOD_IDS}" ]; then
     echo "*** INFO: Found Mods including ${MOD_IDS} ***"
     set_ini_option "Mods" "${MOD_IDS}"
+  else
+    echo "*** INFO: Mod IDs is empty, clearing configuration ***"
+    set_ini_option "Mods" ""
   fi
 
   if [ -n "${WORKSHOP_IDS}" ]; then

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -234,7 +234,7 @@ fi
 # Fixes EOL in script file for good measure
 sed -i 's/\r$//' /server/scripts/search_folder.sh
 # Check 'search_folder.sh' script for details
-WORKSHOP_CONTENT_DIR="${HOMEDIR}/pz-dedicated/steamapps/workshop/content/108600"
+WORKSHOP_CONTENT_DIR="${STEAMAPPDIR}/steamapps/workshop/content/108600"
 MAPS_FILE="${HOMEDIR}/maps.txt"
 SPAWNREGIONS_FILE="${HOMEDIR}/Zomboid/Server/${SERVERNAME}_spawnregions.lua"
 
@@ -270,7 +270,7 @@ if [ -d "${WORKSHOP_CONTENT_DIR}" ]; then
       IFS=";" read -ra strings <<< "$map_list"
       for string in "${strings[@]}"; do
           if ! grep -q "$string" "${SPAWNREGIONS_FILE}"; then
-            if [ -e "${HOMEDIR}/pz-dedicated/media/maps/$string/spawnpoints.lua" ]; then
+            if [ -e "${STEAMAPPDIR}/media/maps/$string/spawnpoints.lua" ]; then
               result="{ name = \"$string\", file = \"media/maps/$string/spawnpoints.lua\" },"
               sed -i "/function SpawnRegions()/,/return {/ {    /return {/ a\
               \\\t\t$result
@@ -296,10 +296,10 @@ fi
 export LD_LIBRARY_PATH="${STEAMAPPDIR}/jre64/lib:${LD_LIBRARY_PATH}"
 
 ## Fix the permissions in the data and workshop folders
-chown -R 1000:1000 /home/steam/pz-dedicated/steamapps/workshop /home/steam/Zomboid
+chown -R "${USER}:${USER}" "${STEAMAPPDIR}/steamapps/workshop" "${HOMEDIR}/Zomboid"
 # When binding a host folder with Docker to the container, the resulting folder has these permissions "d---" (i.e. NO `rwx`) 
 # which will cause runtime issues after launching the server.
 # Fix it the adding back `rwx` permissions for the file owner (steam user)
-chmod 755 /home/steam/Zomboid
+chmod 755 "${HOMEDIR}/Zomboid"
 
 su - steam -c "export LANG=${LANG} && export LD_LIBRARY_PATH=\"${STEAMAPPDIR}/jre64/lib:${LD_LIBRARY_PATH}\" && cd ${STEAMAPPDIR} && pwd && ./start-server.sh ${ARGS}"

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -231,30 +231,54 @@ fi
 # Fixes EOL in script file for good measure
 sed -i 's/\r$//' /server/scripts/search_folder.sh
 # Check 'search_folder.sh' script for details
-if [ -e "${HOMEDIR}/pz-dedicated/steamapps/workshop/content/108600" ]; then
+WORKSHOP_CONTENT_DIR="${HOMEDIR}/pz-dedicated/steamapps/workshop/content/108600"
+MAPS_FILE="${HOMEDIR}/maps.txt"
+SPAWNREGIONS_FILE="${HOMEDIR}/Zomboid/Server/${SERVERNAME}_spawnregions.lua"
 
+if [ -d "${WORKSHOP_CONTENT_DIR}" ]; then
+
+  # Run the script as a child process instead of sourcing it: it ends with `exit 1` when
+  # the folder is not a directory, and while sourced that exit tears down this entrypoint
+  # (and with it the container) before the server is ever started.
+  # The script only ever appends to the file, so drop any leftover from a previous run.
   map_list=""
-  source /server/scripts/search_folder.sh "${HOMEDIR}/pz-dedicated/steamapps/workshop/content/108600"
-  map_list=$(<"${HOMEDIR}/maps.txt")  
-  rm "${HOMEDIR}/maps.txt"
+  rm -f "${MAPS_FILE}"
+  bash /server/scripts/search_folder.sh "${WORKSHOP_CONTENT_DIR}"
+
+  # The file is only written when at least one of the installed mods ships maps, which is
+  # not the case for most mod sets. Reading it unconditionally printed two errors
+  # ("No such file or directory") on every single start.
+  if [ -f "${MAPS_FILE}" ]; then
+    map_list=$(<"${MAPS_FILE}")
+    rm -f "${MAPS_FILE}"
+  fi
 
   if [ -n "${map_list}" ]; then
     echo "*** INFO: Added maps including ${map_list} ***"
-    sed -i "s/Map=.*/Map=${map_list}Muldraugh, KY/" "${HOMEDIR}/Zomboid/Server/${SERVERNAME}.ini"
+    # A `sed` substitution can only rewrite an already existing Map= line. On a brand new
+    # server the INI is still empty at this point, so the maps were silently dropped and
+    # only showed up after an extra restart. set_ini_option appends it when missing.
+    set_ini_option "Map" "${map_list}Muldraugh, KY"
 
     # Checks which added maps have spawnpoints.lua files and adds them to the spawnregions file if they aren't already added
-    IFS=";" read -ra strings <<< "$map_list"
-    for string in "${strings[@]}"; do
-        if ! grep -q "$string" "${HOMEDIR}/Zomboid/Server/${SERVERNAME}_spawnregions.lua"; then
-          if [ -e "${HOMEDIR}/pz-dedicated/media/maps/$string/spawnpoints.lua" ]; then
-            result="{ name = \"$string\", file = \"media/maps/$string/spawnpoints.lua\" },"
-            sed -i "/function SpawnRegions()/,/return {/ {    /return {/ a\
-            \\\t\t$result
-            }" "${HOMEDIR}/Zomboid/Server/${SERVERNAME}_spawnregions.lua"
+    # The server writes the spawnregions file itself on its first run, so it may not be
+    # there yet. Editing it unconditionally failed with an error on every new server.
+    if [ -f "${SPAWNREGIONS_FILE}" ]; then
+      IFS=";" read -ra strings <<< "$map_list"
+      for string in "${strings[@]}"; do
+          if ! grep -q "$string" "${SPAWNREGIONS_FILE}"; then
+            if [ -e "${HOMEDIR}/pz-dedicated/media/maps/$string/spawnpoints.lua" ]; then
+              result="{ name = \"$string\", file = \"media/maps/$string/spawnpoints.lua\" },"
+              sed -i "/function SpawnRegions()/,/return {/ {    /return {/ a\
+              \\\t\t$result
+              }" "${SPAWNREGIONS_FILE}"
+            fi
           fi
-        fi
-    done
-  fi 
+      done
+    else
+      echo "*** INFO: The spawn regions file does not exist yet, the spawn points of the new maps will be added on the next start ***"
+    fi
+  fi
 fi
 
 # Fix to a bug in start-server.sh that causes to no preload a library:

--- a/scripts/get_updates.sh
+++ b/scripts/get_updates.sh
@@ -168,9 +168,18 @@ if [ ${BUILD_UNSTABLE_VERSIONS} == true ]; then
   if [ "${LATEST_IMAGE_UNSTABLE_VERSION}" == "" ] || [ $NEW_VERSION == 1 ]; then
     echo -e "\n\nA new version of the unstable server was detected ($LATEST_UNSTABLE_VERSION). Creating the new image...\n"
 
-    docker build --compress --no-cache --build-arg STEAMAPPBRANCH=unstable -t ${DOCKER_IMAGE}:latest-unstable -t ${DOCKER_IMAGE}:${LATEST_UNSTABLE_VERSION}-unstable .
-    docker push ${DOCKER_IMAGE}:${LATEST_UNSTABLE_VERSION}-unstable
-    docker push ${DOCKER_IMAGE}:latest-unstable
+    # An empty version would build the invalid tag "<image>:-unstable", but above all it
+    # means the version detection failed and the script should stop instead of publishing
+    # something wrong.
+    if [ -z "${LATEST_UNSTABLE_VERSION}" ] || [ "${LATEST_UNSTABLE_VERSION}" == "0.0.0" ]; then
+      echo -e "\n\n*** ERROR: no unstable version could be detected in the forum or the website, aborting ***\n\n"
+      exit 1
+    fi
+
+    # Stop at the first failure instead of pushing tags that were never built.
+    docker build --compress --no-cache --build-arg STEAMAPPBRANCH=unstable -t ${DOCKER_IMAGE}:latest-unstable -t ${DOCKER_IMAGE}:${LATEST_UNSTABLE_VERSION}-unstable . || exit 1
+    docker push ${DOCKER_IMAGE}:${LATEST_UNSTABLE_VERSION}-unstable || exit 1
+    docker push ${DOCKER_IMAGE}:latest-unstable || exit 1
   elif [ $NEW_VERSION == 0 ]; then
     echo -e "\n\nThere is no new unstable version of the Zomboid server\n\n"
   elif [ $NEW_VERSION == -1 ]; then
@@ -189,10 +198,21 @@ NEW_VERSION=$(versionCompare ${LATEST_STABLE_VERSION} ${LATEST_IMAGE_STABLE_VERS
 if [ "${LATEST_IMAGE_STABLE_VERSION}" == "" ] || [ $NEW_VERSION == 1 ]; then
   echo -e "\n\nA new version of the stable server was detected ($LATEST_STABLE_VERSION). Creating the new image...\n"
 
-  docker build --compress --no-cache -t ${DOCKER_IMAGE}:latest -t ${DOCKER_IMAGE}:latest-release -t ${DOCKER_IMAGE}:${LATEST_STABLE_VERSION}-release .
-  docker push ${DOCKER_IMAGE}:${LATEST_STABLE_VERSION}-release
-  docker push ${DOCKER_IMAGE}:latest-release
-  docker push ${DOCKER_IMAGE}:latest
+  # An empty version would build the invalid tag "<image>:-release", but above all it
+  # means the version detection failed and the script should stop instead of publishing
+  # something wrong.
+  if [ -z "${LATEST_STABLE_VERSION}" ] || [ "${LATEST_STABLE_VERSION}" == "0.0.0" ]; then
+    echo -e "\n\n*** ERROR: no stable version could be detected in the forum or the website, aborting ***\n\n"
+    exit 1
+  fi
+
+  # Stop at the first failure. Only the exit status of the last push used to be reported,
+  # so a failed build or a failed intermediate push was masked by the "latest" push that
+  # followed it and the job still looked green.
+  docker build --compress --no-cache -t ${DOCKER_IMAGE}:latest -t ${DOCKER_IMAGE}:latest-release -t ${DOCKER_IMAGE}:${LATEST_STABLE_VERSION}-release . || exit 1
+  docker push ${DOCKER_IMAGE}:${LATEST_STABLE_VERSION}-release || exit 1
+  docker push ${DOCKER_IMAGE}:latest-release || exit 1
+  docker push ${DOCKER_IMAGE}:latest || exit 1
 elif [ $NEW_VERSION == 0 ]; then
   echo -e "\n\nThere is no new stable version of the Zomboid server\n\n"
 elif [ $NEW_VERSION == -1 ]; then

--- a/scripts/search_folder.sh
+++ b/scripts/search_folder.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
+# An empty folder would otherwise leave the glob unexpanded and the loops would run once
+# with a path that ends in a literal "*".
+shopt -s nullglob
+
 # Function to recursively search for a folder name
 search_folder() {
     local search_dir="$1"
+    local items=("$search_dir"/*)
     counter=1
 
-    for item in "$search_dir"/*; do
+    for item in "${items[@]}"; do
 
-        echo "Searching for maps: ($counter/$(ls -1 "$search_dir" | wc -l))"
+        echo "Searching for maps: ($counter/${#items[@]})"
 
         # Check if the given directory exists
         if [ -d "$search_dir" ]; then                
@@ -23,8 +28,11 @@ search_folder() {
                         for source_dir in "${source_dirs[@]}"; do
                             dir_name=$(basename "$source_dir")
                             if [ ! -d "$map_dir/$dir_name" ]; then
-                                echo "Found map(s). Copying..."
-                                cp -r "$mod_folder/media/maps"/* "${map_dir}"
+                                echo "Found map(s). Copying $dir_name..."
+                                # Copy only the map that is missing. Copying the whole
+                                # folder re-copied (and overwrote) every map the mod
+                                # ships as soon as a single one of them was missing.
+                                cp -r "$source_dir" "${map_dir}"
                                 echo "Successfully copied!"
                             fi
                         done

--- a/scripts/search_folder.sh
+++ b/scripts/search_folder.sh
@@ -18,13 +18,13 @@ search_folder() {
                 
                         # Copy maps to map folder
                         source_dirs=("$mod_folder/media/maps"/*)
-                        map_dir=("${HOMEDIR}/pz-dedicated/media/maps")
+                        map_dir="${STEAMAPPDIR}/media/maps"
 
                         for source_dir in "${source_dirs[@]}"; do
                             dir_name=$(basename "$source_dir")
                             if [ ! -d "$map_dir/$dir_name" ]; then
                                 echo "Found map(s). Copying..."
-                                cp -r "$mod_folder/media/maps"/* "${HOMEDIR}/pz-dedicated/media/maps"
+                                cp -r "$mod_folder/media/maps"/* "${map_dir}"
                                 echo "Successfully copied!"
                             fi
                         done


### PR DESCRIPTION
Ten independent fixes found while reading through the entrypoint. Every commit stands on
its own and can be dropped or cherry-picked without touching the others.

Does not conflict with #43 (verified by merging both).

### Bugs

* **`FORCEUPDATE` never updated the public branch.** The Dockerfile already special cases
  it, because SteamCMD has no beta named `public`, but the entrypoint always appended
  `-beta "${STEAMAPPBRANCH}"`, so on the default branch the forced update silently did
  nothing.
* **Mod maps were lost on the first boot.** Since the INI is pre-created empty, the
  `sed "s/Map=.*/..."` substitution had no line to rewrite and the maps only appeared
  after an extra restart. Now applied through the existing `set_ini_option`.
* **Two errors on every start of a server with mods but no map mods.**
  `search_folder.sh` only writes `maps.txt` when a mod actually ships maps, but it was
  read and deleted unconditionally.
* **The spawnregions file was edited before the server had created it**, failing with
  `grep`/`sed: No such file or directory` on every new server.
* **`search_folder.sh` was sourced**, so its `exit 1` would terminate the entrypoint
  itself and the container would die before starting the server instead of just skipping
  the map search.
* **`PORT`/`UDPPORT` were ignored by the compose file**, which always published
  16261/16262, leaving the server unreachable when either was changed.
* **`.env.template` shipped `LANG=en_EN.UTF-8`**, which is not a real locale, and the
  image only generated `es_ES.UTF-8`, so any other language was silently ignored by
  glibc. The locale list is now an `EXTRA_LOCALES` build argument (same default) and a
  warning is printed when the requested locale is missing.
* **`get_updates.sh` pushed after a failed build**, and only the exit status of the last
  push reached CI, so a failure could still leave a green job.

### Behaviour change worth a separate look

`MOD_IDS` empty now clears `Mods`, like `WORKSHOP_IDS` already does for `WorkshopItems`.
Removing both variables from the `.env` used to produce a half updated INI where the
workshop items were gone but `Mods` still listed them, and the server refused to start.
`SELF_MANAGED_MODS` is the supported escape hatch and the README documents the new
behaviour. This is the one commit that changes something for existing users, so it is
isolated in `fix: clear Mods when MOD_IDS is empty`.

### Housekeeping

Paths derived from `STEAMAPPDIR` instead of a hardcoded `/home/steam/pz-dedicated`, the
recursive `chown` using `${USER}` instead of UID 1000, `nullglob` and a couple of
redundant `ls`/`cp` calls removed from the map search, `.gitattributes` forcing LF for the
files that run inside the container (which is what `dos2unix` and `sed -i 's/\r$//'` are
working around at runtime), the obsolete compose `version` key, and the CI actions moved
off the deprecated Node 16 runtime.

### Testing

No Docker build was run. The scripts were exercised on Linux with stubs for
`start-server.sh`, `runuser`, `chown` and `chmod`, against a fake workshop tree
containing one mod with a map:

* Before: the generated INI has no `Map=` line and the run prints the two
  `spawnregions ... No such file or directory` errors.
* After: `Map=BedfordFalls;Muldraugh, KY` is written on the first boot, the errors are
  replaced by an informational message, and the same map folders end up copied.

The map search was diffed old vs new on the same tree: identical `maps.txt` and identical
copied folders.
