### PR TITLE
fix: skip the unstable image when there is no open beta

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,7 @@
 # Empty Strings are ignored or equivalent to false
-# STEAMAPPBRANCH=unstable
+# Beta branch to build. Leave it commented out to use the stable (public) branch, which
+# is where Build 42 lives now. There is no open beta at the moment.
+# STEAMAPPBRANCH=<branch-name>
 LANG=en_US.UTF-8
 NOSTEAM=False
 CACHEDIR=

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout the latest version
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/README.MD
+++ b/README.MD
@@ -6,7 +6,7 @@ The ready to use image is available here:
 
 https://hub.docker.com/r/danixu86/project-zomboid-dedicated-server
 
-> **Note:** If you want to play **Build 42** multiplayer, you must set the `STEAMAPPBRANCH` [environment variable](#run-time-environment-variables) to `unstable`.
+> **Note:** Build 42 is now the stable build, so the default image already runs it. The `unstable` branch this note used to point at no longer exists on Steam: setting `STEAMAPPBRANCH` to it today fails the build with `ERROR! Failed to set beta 'unstable'`. See [SteamDB](https://steamdb.info/app/108600/depots/) for the branches that currently exist.
 
 **WARNING:** Running the image on Windows using WSL2 in Docker Desktop will make the server startup times significantly slower. This is fine unless you are running alot of mods in which case server startup times may vary from 15 - 40 minutes. The best way to solve this problem is to run your container on a Linux based system or in a Linux VM.
 
@@ -80,12 +80,12 @@ Maps are added on the same start on which the mods are detected, right after the
 
 This env variables will be used at build time to generate the image.
 
-`STEAMAPPBRANCH:` Sets the Project Zomboid branch to download (e.g., `unstable`). If not set, the stable (public) branch will be downloaded. You can see a list of branches in the [SteamDB website](https://steamdb.info/app/108600/depots/).
+`STEAMAPPBRANCH:` Sets the Project Zomboid beta branch to download. If not set, the stable (public) branch is used, which is what you want unless a beta is currently open. You can see a list of branches in the [SteamDB website](https://steamdb.info/app/108600/depots/).
 
 This will work only when using the `docker compose` command. If you are building the image using the `docker build` command, then must be passed as argument, for example:
 
 ```bash
-docker build --compress --no-cache --build-arg STEAMAPPBRANCH=unstable .
+docker build --compress --no-cache --build-arg STEAMAPPBRANCH=<branch-name> .
 ```
 
 ## Soft Reset

--- a/scripts/get_updates.sh
+++ b/scripts/get_updates.sh
@@ -165,7 +165,16 @@ if [ ${BUILD_UNSTABLE_VERSIONS} == true ]; then
 
   NEW_VERSION=$(versionCompare ${LATEST_UNSTABLE_VERSION} ${LATEST_IMAGE_UNSTABLE_VERSION})
 
-  if [ "${LATEST_IMAGE_UNSTABLE_VERSION}" == "" ] || [ $NEW_VERSION == 1 ]; then
+  # Project Zomboid does not always have an open beta. When Build 42 became stable the
+  # "unstable" beta was removed from Steam, but the forum and the website keep reporting a
+  # version for it (the very same one as the stable build), so the script went on trying
+  # to build it and SteamCMD answered "ERROR! Failed to set beta 'unstable'" every time.
+  # A beta is only worth building while it is actually ahead of the stable build.
+  UNSTABLE_AHEAD=$(versionCompare ${LATEST_UNSTABLE_VERSION} ${LATEST_STABLE_VERSION})
+
+  if [ "${UNSTABLE_AHEAD}" != 1 ]; then
+    echo -e "\n\nThe detected unstable version (${LATEST_UNSTABLE_VERSION}) is not ahead of the stable one (${LATEST_STABLE_VERSION}), so there is no open beta right now. Skipping the unstable image.\n\n"
+  elif [ "${LATEST_IMAGE_UNSTABLE_VERSION}" == "" ] || [ $NEW_VERSION == 1 ]; then
     echo -e "\n\nA new version of the unstable server was detected ($LATEST_UNSTABLE_VERSION). Creating the new image...\n"
 
     # An empty version would build the invalid tag "<image>:-unstable", but above all it


### PR DESCRIPTION
The scheduled build has been failing since 2026-08-30. The error is in the SteamCMD step:

```
ERROR! Failed to set beta 'unstable'
```

Project Zomboid does not always have a beta branch open. When Build 42 became stable the
`unstable` beta was removed from Steam, but the forum and the website keep reporting a
version for it — and that version is now simply the stable one. Both currently resolve to
42.20.4:

```
Latest docker images version:
	RELEASE: 42.20.4
	UNSTABLE: 42.19.0
Detected real latest versions (forum and website):
	RELEASE: 42.20.4
	UNSTABLE: 42.20.4
A new version of the unstable server was detected (42.20.4). Creating the new image...
```

So the script sees 42.20.4 as newer than the last unstable image (42.19.0, published back
in June), tries to build it, and SteamCMD refuses because the beta no longer exists. The
release image is unaffected and up to date.

### Fix

A beta is only worth building while it is actually ahead of the stable build, so compare
the two and skip the unstable image when it is not. It resumes on its own as soon as a new
beta appears with a version ahead of stable, and genuine build failures still abort the
run.

Verified against the live forum and website data with `docker` stubbed to fail:

* before: `A new version of the unstable server was detected (42.20.4)` → build fails →
  exit 1
* after: `The detected unstable version (42.20.4) is not ahead of the stable one
  (42.20.4), so there is no open beta right now. Skipping the unstable image.` → exit 0,
  and the stable section still runs normally

### Also

The action bump in #44 landed on `actions/checkout@v4` and `docker/login-action@v3`, which
are themselves Node 20 and now produce a deprecation warning on every run. Moved to the
current majors, v7 and v4. My mistake in that PR.

### And the README

The note at the top of the README still tells anyone who wants Build 42 multiplayer to set
`STEAMAPPBRANCH=unstable`. That is the same dead branch, so following the README today
fails the build with the exact error above. Build 42 is the stable build now — the image
already publishes it as `42.20.4-release` — so the default needs no variable at all.
Updated the note, the `STEAMAPPBRANCH` docs, the `docker build` example and the `.env`
template to point at SteamDB rather than naming a branch that no longer exists.
