### PR TITLE
feat: allow forcing a rebuild when the scripts change

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,6 +4,11 @@ on:
   schedule:
   - cron: "0 */6 * * *"
   workflow_dispatch:
+    inputs:
+      force_build:
+        description: "Rebuild and publish the current version as a new revision, even when no new server version is detected. Use it after changing the Dockerfile or the scripts."
+        type: boolean
+        default: false
 
 jobs:
 
@@ -23,6 +28,8 @@ jobs:
     
       - name: Check the latest version and push new versions
         shell: bash
+        env:
+          FORCE_BUILD: ${{ inputs.force_build }}
         run: |
           # make file runnable, might not be necessary
           chmod +x "${GITHUB_WORKSPACE}/scripts/get_updates.sh"

--- a/README.MD
+++ b/README.MD
@@ -154,3 +154,7 @@ In the scripts folders there are three scripts:
 * entry.sh: The script used in the image to start the server
 * search_folder.sh: Script to search through mod folders for any maps
 * get_updates.sh: will perform a search of the latest version on the forum and the website to download and build the latest stable and unstable version. The local image will be created and it will try to upload the image to the Dockerhub website, but it will fail by the lack of permissions.
+
+The image is only rebuilt when Project Zomboid itself gets a new version, so a change to the Dockerfile or to the scripts does not reach Docker Hub on its own. To publish one, run the `Docker Image CI` workflow manually with the `force_build` option ticked, or run the script by hand with `FORCE_BUILD=true ./scripts/get_updates.sh`.
+
+A version that is already published is never overwritten: rebuilding it publishes a new revision of that version (`42.20.4-release-2`, then `-3`, and so on) and moves `latest` and `latest-release` to it, so a pinned version tag always keeps pointing at the same image.

--- a/scripts/get_updates.sh
+++ b/scripts/get_updates.sh
@@ -11,6 +11,11 @@ DOCKER_IMAGE="danixu86/project-zomboid-dedicated-server"
 PZ_URL_WEB="https://projectzomboid.com/blog/"
 PZ_URL_FORUM="https://theindiestone.com/forums/forum/35-pz-updates/"
 BUILD_UNSTABLE_VERSIONS=true
+# Build even when the detected server version is not newer than the published image. The
+# image is only rebuilt when Project Zomboid itself gets a new version, so a change to the
+# Dockerfile or to the scripts never reaches Docker Hub on its own. The result is published
+# as a new revision of the current version, never on top of the existing tag.
+FORCE_BUILD="${FORCE_BUILD:-false}"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "${SCRIPT_DIR}/../"
@@ -174,8 +179,12 @@ if [ ${BUILD_UNSTABLE_VERSIONS} == true ]; then
 
   if [ "${UNSTABLE_AHEAD}" != 1 ]; then
     echo -e "\n\nThe detected unstable version (${LATEST_UNSTABLE_VERSION}) is not ahead of the stable one (${LATEST_STABLE_VERSION}), so there is no open beta right now. Skipping the unstable image.\n\n"
-  elif [ "${LATEST_IMAGE_UNSTABLE_VERSION}" == "" ] || [ $NEW_VERSION == 1 ]; then
-    echo -e "\n\nA new version of the unstable server was detected ($LATEST_UNSTABLE_VERSION). Creating the new image...\n"
+  elif [ "${FORCE_BUILD}" == "true" ] || [ "${LATEST_IMAGE_UNSTABLE_VERSION}" == "" ] || [ $NEW_VERSION == 1 ]; then
+    if [ "${FORCE_BUILD}" == "true" ]; then
+      echo -e "\n\nFORCE_BUILD is set, rebuilding the unstable image ($LATEST_UNSTABLE_VERSION) as a new revision...\n"
+    else
+      echo -e "\n\nA new version of the unstable server was detected ($LATEST_UNSTABLE_VERSION). Creating the new image...\n"
+    fi
 
     # An empty version would build the invalid tag "<image>:-unstable", but above all it
     # means the version detection failed and the script should stop instead of publishing
@@ -216,8 +225,12 @@ echo -e "\n\n*******************************************************************
 echo "Checking the latest stable version..."
 NEW_VERSION=$(versionCompare ${LATEST_STABLE_VERSION} ${LATEST_IMAGE_STABLE_VERSION})
 
-if [ "${LATEST_IMAGE_STABLE_VERSION}" == "" ] || [ $NEW_VERSION == 1 ]; then
-  echo -e "\n\nA new version of the stable server was detected ($LATEST_STABLE_VERSION). Creating the new image...\n"
+if [ "${FORCE_BUILD}" == "true" ] || [ "${LATEST_IMAGE_STABLE_VERSION}" == "" ] || [ $NEW_VERSION == 1 ]; then
+  if [ "${FORCE_BUILD}" == "true" ]; then
+    echo -e "\n\nFORCE_BUILD is set, rebuilding the stable image ($LATEST_STABLE_VERSION) as a new revision...\n"
+  else
+    echo -e "\n\nA new version of the stable server was detected ($LATEST_STABLE_VERSION). Creating the new image...\n"
+  fi
 
   # An empty version would build the invalid tag "<image>:-release", but above all it
   # means the version detection failed and the script should stop instead of publishing

--- a/scripts/get_updates.sh
+++ b/scripts/get_updates.sh
@@ -186,8 +186,20 @@ if [ ${BUILD_UNSTABLE_VERSIONS} == true ]; then
     fi
 
     # Stop at the first failure instead of pushing tags that were never built.
-    docker build --compress --no-cache --build-arg STEAMAPPBRANCH=unstable -t ${DOCKER_IMAGE}:latest-unstable -t ${DOCKER_IMAGE}:${LATEST_UNSTABLE_VERSION}-unstable . || exit 1
-    docker push ${DOCKER_IMAGE}:${LATEST_UNSTABLE_VERSION}-unstable || exit 1
+    # Same as the stable image: an already published version is republished as the next
+    # revision instead of overwriting the tag someone may have pinned.
+    UNSTABLE_TAG="${LATEST_UNSTABLE_VERSION}-unstable"
+    if echo "${LATEST_IMAGES}" | grep -q "\"${UNSTABLE_TAG}\""; then
+      REVISION=2
+      while echo "${LATEST_IMAGES}" | grep -q "\"${LATEST_UNSTABLE_VERSION}-unstable-${REVISION}\""; do
+        REVISION=$((REVISION + 1))
+      done
+      UNSTABLE_TAG="${LATEST_UNSTABLE_VERSION}-unstable-${REVISION}"
+      echo "Version ${LATEST_UNSTABLE_VERSION} is already published, publishing it as ${UNSTABLE_TAG} to leave the existing tag untouched"
+    fi
+
+    docker build --compress --no-cache --build-arg STEAMAPPBRANCH=unstable -t ${DOCKER_IMAGE}:latest-unstable -t ${DOCKER_IMAGE}:${UNSTABLE_TAG} . || exit 1
+    docker push ${DOCKER_IMAGE}:${UNSTABLE_TAG} || exit 1
     docker push ${DOCKER_IMAGE}:latest-unstable || exit 1
   elif [ $NEW_VERSION == 0 ]; then
     echo -e "\n\nThere is no new unstable version of the Zomboid server\n\n"
@@ -218,8 +230,22 @@ if [ "${LATEST_IMAGE_STABLE_VERSION}" == "" ] || [ $NEW_VERSION == 1 ]; then
   # Stop at the first failure. Only the exit status of the last push used to be reported,
   # so a failed build or a failed intermediate push was masked by the "latest" push that
   # followed it and the job still looked green.
-  docker build --compress --no-cache -t ${DOCKER_IMAGE}:latest -t ${DOCKER_IMAGE}:latest-release -t ${DOCKER_IMAGE}:${LATEST_STABLE_VERSION}-release . || exit 1
-  docker push ${DOCKER_IMAGE}:${LATEST_STABLE_VERSION}-release || exit 1
+  # Never overwrite a version tag that is already published: whoever pinned
+  # 42.20.4-release has to keep getting the very same image. When the version is already
+  # out and the image is built again (because the Dockerfile or the scripts changed), it
+  # goes out as the next revision of that version instead, and the moving tags follow it.
+  STABLE_TAG="${LATEST_STABLE_VERSION}-release"
+  if echo "${LATEST_IMAGES}" | grep -q "\"${STABLE_TAG}\""; then
+    REVISION=2
+    while echo "${LATEST_IMAGES}" | grep -q "\"${LATEST_STABLE_VERSION}-release-${REVISION}\""; do
+      REVISION=$((REVISION + 1))
+    done
+    STABLE_TAG="${LATEST_STABLE_VERSION}-release-${REVISION}"
+    echo "Version ${LATEST_STABLE_VERSION} is already published, publishing it as ${STABLE_TAG} to leave the existing tag untouched"
+  fi
+
+  docker build --compress --no-cache -t ${DOCKER_IMAGE}:latest -t ${DOCKER_IMAGE}:latest-release -t ${DOCKER_IMAGE}:${STABLE_TAG} . || exit 1
+  docker push ${DOCKER_IMAGE}:${STABLE_TAG} || exit 1
   docker push ${DOCKER_IMAGE}:latest-release || exit 1
   docker push ${DOCKER_IMAGE}:latest || exit 1
 elif [ $NEW_VERSION == 0 ]; then


### PR DESCRIPTION
The scheduled job is green again after #46, but it never publishes anything, and that
hides a second problem: **the image on Docker Hub is older than the fixes**.

| | |
|---|---|
| `latest` published | 2026-08-26 |
| #44 merged | 2026-08-28 |
| #45 merged | 2026-08-30 |
| #46 merged | 2026-09-01 |

`get_updates.sh` only builds when Project Zomboid itself gets a new version, so a change to
the Dockerfile or to the entrypoint never reaches Docker Hub on its own. Anyone pulling the
image today still gets the entrypoint from before the first boot fixes and before the admin
password fix. Triggering the workflow by hand does not help — the script finds no new
version and exits without building, which is what the manual run did in 16 seconds.

### Not overwriting published tags

The obvious fix, rebuilding the same version, would replace the image behind
`42.20.4-release` with different content, and a pinned version tag exists precisely so that
does not happen.

So the first commit checks whether the tag is already on Docker Hub and, when it is,
publishes the build as the next revision of that version — `42.20.4-release-2`, then `-3` —
while `latest` and `latest-release` move to the new image. The version detection is
unaffected: it pulls the version out with a regex that ignores whatever follows it.

### The flag

The second commit adds a `force_build` input to `workflow_dispatch`, passed to the script
as `FORCE_BUILD`. Tick the box when the scripts change; leave it alone and the schedule
behaves exactly as before.

The unstable image stays skipped when there is no open beta even with the flag set, since
forcing a build of a branch that does not exist on Steam would only bring back the SteamCMD
failure from #46. Every other guard is kept: an undetected version still aborts, and a
failed build or push still stops the run.

### Testing

Against the live version data, with `docker` stubbed:

* flag unset → `There is no new stable version` and nothing is built
* `FORCE_BUILD=true` → builds and pushes `42.20.4-release-2`, `latest-release` and
  `latest`, with the unstable image still skipped

The revision picker was checked on its own for a version that is not published yet (plain
tag), one that is (`-2`), ones that already have revisions (`-3`, `-4`), and a
similar-looking neighbour (`42.20.40-release` correctly does not match `42.20.4-release`).

Merging this and then running the workflow once with the box ticked is what will finally
put #44, #45 and #46 into the published image.
