### PR TITLE
fix: merge the Map INI line instead of rebuilding it on every start

### DIFF
--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -263,7 +263,39 @@ if [ -d "${WORKSHOP_CONTENT_DIR}" ]; then
     # A `sed` substitution can only rewrite an already existing Map= line. On a brand new
     # server the INI is still empty at this point, so the maps were silently dropped and
     # only showed up after an extra restart. set_ini_option appends it when missing.
-    set_ini_option "Map" "${map_list}Muldraugh, KY"
+    # Merge the detected maps into the Map= line instead of rebuilding it from the scan.
+    # Rebuilding threw away every manual edit on each start: a map folder shipped by two
+    # mod folders (a map plus its patch mod, or a B41 and a B42 copy inside one workshop
+    # item) landed in the line twice, e.g. "Map=AZSpawn;AZSpawn;Muldraugh, KY"; map folders
+    # the scan cannot see (a mod that is not laid out as mods/<mod>/media/maps) were
+    # dropped; and the load order the admin chose was replaced by the order the folders
+    # happen to be read in.
+    BASE_MAP="Muldraugh, KY"
+    current_maps=""
+    if [ -f "${SERVERINI}" ] && grep -q "^Map=" "${SERVERINI}"; then
+      current_maps="$(grep -m1 "^Map=" "${SERVERINI}" | cut -d "=" -f2-)"
+    fi
+
+    merged_maps=""
+    add_map() {
+      [ -z "${1}" ] && return
+      [ "${1}" == "${BASE_MAP}" ] && return
+      case ";${merged_maps}" in *";${1};"*) return;; esac
+      merged_maps+="${1};"
+    }
+
+    # What the INI already lists keeps its place, anything newly found is appended after
+    # it, and the base map stays last where the game expects it.
+    IFS=";" read -ra current_entries <<< "${current_maps}"
+    for entry in "${current_entries[@]}"; do
+      add_map "${entry}"
+    done
+    IFS=";" read -ra found_entries <<< "${map_list}"
+    for entry in "${found_entries[@]}"; do
+      add_map "${entry}"
+    done
+
+    set_ini_option "Map" "${merged_maps}${BASE_MAP}"
 
     # Checks which added maps have spawnpoints.lua files and adds them to the spawnregions file if they aren't already added
     # The server writes the spawnregions file itself on its first run, so it may not be


### PR DESCRIPTION
### The problem

The `Map=` line is rebuilt from the workshop scan on every container start, so it overwrites whatever the admin put there. A server admin reported this on a server of ours: they had set

```
Map=AZSpawn;vehicle_interior_arcadia75;Muldraugh, KY
```

and after a restart the entrypoint had turned it into

```
Map=AZSpawn;AZSpawn;Muldraugh, KY
```

Three separate things go wrong, all from the same cause:

- **Duplicates.** `search_folder.sh` emits one entry per `media/maps/<folder>` it finds and does not deduplicate, so a map folder shipped by two mod folders (a map plus its patch/compat mod, or a B41 and a B42 copy inside one workshop item) lands in the line twice.
- **Dropped entries.** A map that the scan cannot see, because the mod is not laid out as `mods/<mod>/media/maps`, is not in `map_list`, and since the line is rebuilt rather than merged the admin's manual entry for it is erased.
- **Lost order.** The load order the admin chose is replaced by the order the folders happen to be read in, which matters for overlapping maps.

`SELF_MANAGED_MODS` does not help here: it covers `Mods` and `WorkshopItems`, not `Map`.

### The change

The line is merged instead of rebuilt:

- what the INI already lists keeps its place and its order;
- detected maps that are not in the line yet are appended after it;
- duplicates are dropped;
- `Muldraugh, KY` stays last, where the game expects it.

Newly installed map mods are still picked up automatically, which is the useful half of the original behaviour, and running the entrypoint again over its own output is a no-op.

### Testing

Ran the merge block against a fixture INI for each case:

| case | before | after |
| --- | --- | --- |
| reported case (scan yields `AZSpawn;AZSpawn;`) | `Map=AZSpawn;vehicle_interior_arcadia75;Muldraugh, KY` | unchanged |
| fresh server, one map mod detected | `Map=Muldraugh, KY` | `Map=AZSpawn;Muldraugh, KY` |
| new map mod on top of a manual list | `Map=AZSpawn;vehicle_interior_arcadia75;Muldraugh, KY` | `Map=AZSpawn;vehicle_interior_arcadia75;BedfordFalls;Muldraugh, KY` |
| run again over the previous result | unchanged | unchanged |
| no `Map=` line in the INI | — | `Map=AZSpawn;Muldraugh, KY` (appended by `set_ini_option`) |

### Note on publishing

The newest published tag is `42.20.4-release` from 26 Aug, so this fix (and #44 to #47) will only reach servers on a rebuild. If you are happy with the change, a `force_build` run of the workflow would get it out without waiting for the next game version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwVXPRESc6MqoNGtGQ3mtn